### PR TITLE
travis: Enable cache for $HOME/.cargo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: rust
 rust:
-    - stable
+  - stable
+cache:
+  directories:
+    - $HOME/.cargo


### PR DESCRIPTION
This should improve build time since the cargo registry and dependencies won't need to download every time.