### PR TITLE
Graceful error handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,10 @@ fn main() {
     let keyword = args.get_str("<searchterm>");
     let mut torrents = vec![];
     for provider in providers.iter() {
-        torrents.push(provider.search(keyword));
+        match provider.search(keyword) {
+            Ok(results) => torrents.extend(results),
+            Err(err) => println!("Error: {}", err),
+        }
     }
 
     // print out all torrents

--- a/src/search_providers/kickass_search.rs
+++ b/src/search_providers/kickass_search.rs
@@ -8,6 +8,7 @@ use select::document::Document;
 use select::node::Node;
 use select::predicate::{Attr, Class, Name};
 
+use std::error::Error;
 use std::io::Read;
 
 use hyper::Client;
@@ -28,17 +29,17 @@ impl KickassSearch {
 }
 
 impl SearchProvider for KickassSearch {
-    fn search(&self, term: &str) -> Vec<Torrent> {
-        let res = self.connection.get(&format!("https://kat.cr/usearch/{}", term))
+    fn search(&self, term: &str) -> Result<Vec<Torrent>,Box<Error>> {
+        let res = try!(self.connection.get(&format!("https://kat.cr/usearch/{}", term))
             .header(Connection::close())
-            .send().unwrap();
+            .send());
 
         let mut body = String::new();
         let mut d = GzDecoder::new(res).unwrap();
-        d.read_to_string(&mut body).unwrap();
+        try!(d.read_to_string(&mut body));
 
         let document = Document::from_str(&body);
-        parse_kickass(&document)
+        Ok(parse_kickass(&document))
     }
 }
 

--- a/src/search_providers/mod.rs
+++ b/src/search_providers/mod.rs
@@ -1,8 +1,9 @@
 use torrent::Torrent;
+use std::error::Error;
 
 pub mod pirate_bay_search;
 pub mod kickass_search;
 
 pub trait SearchProvider {
-    fn search(&self, term: &str) -> Vec<Torrent>;
+    fn search(&self, term: &str) -> Result<Vec<Torrent>,Box<Error>>;
 }

--- a/src/search_providers/pirate_bay_search.rs
+++ b/src/search_providers/pirate_bay_search.rs
@@ -5,6 +5,7 @@ use select::document::Document;
 use select::node::Node;
 use select::predicate::{Attr, Class, Name};
 
+use std::error::Error;
 use std::io::Read;
 
 use hyper::Client;
@@ -25,16 +26,16 @@ impl PirateBaySearch {
 }
 
 impl SearchProvider for PirateBaySearch {
-    fn search(&self, term: &str) -> Vec<Torrent> {
-        let mut res = self.connection.get(&format!("https://thepiratebay.to/search/{}/0/99/0", term))
+    fn search(&self, term: &str) -> Result<Vec<Torrent>,Box<Error>> {
+        let mut res = try!(self.connection.get(&format!("https://thepiratebay.to/search/{}/0/99/0", term))
             .header(Connection::close())
-            .send().unwrap();
+            .send());
 
         let mut body = String::new();
-        res.read_to_string(&mut body).unwrap();
+        try!(res.read_to_string(&mut body));
 
         let document = Document::from_str(&body);
-        parse_piratebay(&document)
+        Ok(parse_piratebay(&document))
     }
 }
 


### PR DESCRIPTION
Currently if connection to a search provider fails the program just panics.
See [here](https://github.com/rnestler/rust-torrent-search/blob/a348198491731461c25901222ef074cf6552d67d/src/search_providers/kickass_search.rs#L34):
```Rust
let res = self.connection.get(&format!("https://kat.cr/usearch/{}", term))
    .header(Connection::close())
    .send().unwrap();

let mut body = String::new();
let mut d = GzDecoder::new(res).unwrap();
d.read_to_string(&mut body).unwrap();
```
and [here](https://github.com/rnestler/rust-torrent-search/blob/a348198491731461c25901222ef074cf6552d67d/src/search_providers/pirate_bay_search.rs#L31):
```Rust
let mut res = self.connection.get(&format!("https://thepiratebay.mn/search/{}/0/99/0", term))
    .header(Connection::close())
    .send().unwrap();

let mut body = String::new();
res.read_to_string(&mut body).unwrap();
```
To fix this we should
 - [x] Change the [SearchProvider trait](https://github.com/rnestler/rust-torrent-search/blob/a348198491731461c25901222ef074cf6552d67d/src/search_providers/mod.rs#L6) to return `Result`
 - [x] Use the `try!` macro instead of `unwrap()`