### PR TITLE
Remove 32bit Windows build from AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,7 @@
 environment:
-  matrix:
-    - TARGET: i686-pc-windows-gnu
-      RUST_VERSION: 1.32.0
-      BITS: 32
-    - TARGET: x86_64-pc-windows-gnu
-      RUST_VERSION: 1.32.0
-      BITS: 64
+  TARGET: x86_64-pc-windows-gnu
+  RUST_VERSION: 1.32.0
+  BITS: 64
 install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-${env:RUST_VERSION}-${env:TARGET}.exe"
   - rust-%RUST_VERSION%-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Rust"
@@ -17,8 +13,7 @@ install:
   - cargo -V
 
 build_script:
-    - cargo build --verbose
+  - cargo build --verbose
 
 test_script:
-    - cargo test --verbose
-
+  - cargo test --verbose


### PR DESCRIPTION
AppVeyor is slow and 32bit Windows isn't really important to me.