### PR TITLE
Update README.md: `cargo run "search term" ` works just as well. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To install openssl on Windows see [here](https://github.com/sfackler/rust-openss
 Just execute
 
 ```
-$ cargo run -- "search term"
+$ cargo run "search term"
 ```
 
 To search for "search term" in all supported sources.


### PR DESCRIPTION
Update README.md: `cargo run "search term" ` works just as well as: `cargo run -- "search term" `. I removed `--` from the usage instructions.
