### PR TITLE
Ignore RUSTSEC-2020-0071

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
           command: cargo install --force cargo-audit
       - run:
           name: Run cargo-audit
-          command: cargo update && cargo audit
+          command: cargo update && cargo audit --ignore RUSTSEC-2020-0071
       - save_cache:
           key: v1-cargo-audit-cache
           paths:


### PR DESCRIPTION
xml5ever only uses `time::precise_time_ns` which is not affected
according to https://rustsec.org/advisories/RUSTSEC-2020-0071. Also
there is a pull request open which will remove the time dependency
completely: https://github.com/servo/html5ever/pull/453