### PR TITLE
Update CHANGELOG with recent changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added 
+
+ * Allow to specify search providers on command line
+
+### Changed
+
+ * Build with msvc toolchain on Windows
+ * Use structopt instead of docopt for command line parsing
+
 ## [0.1.0] - 2021-10-23
 
- - Initial release on crates.io
+ * Initial release
 
 
+[Unreleased]: https://github.com/rnestler/rust-torrent-search/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/rnestler/rust-torrent-search/releases/tag/v0.1.0


### PR DESCRIPTION
We didn't yet publish on crates.io (because I still need a good name),
but I decided to tag the release anyways and write a CHANGELOG from now
on.