### PR TITLE
Filter out the empty pirate bay response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Build with msvc toolchain on Windows
  * Use structopt instead of docopt for command line parsing
 
+### Fixed
+
+ * Do not output error message pseudo torrent from piratebay
+
 ## [0.1.0] - 2021-10-23
 
  * Initial release

--- a/src/search_providers/pirate_bay_search.rs
+++ b/src/search_providers/pirate_bay_search.rs
@@ -71,6 +71,11 @@ fn parse_piratebay(content: &str) -> Result<Vec<Torrent>, Box<dyn Error + Send +
 
     let results = entries
         .iter()
+        .filter(|entry| {
+            entry.id != "0"
+                && entry.name != "No results returned"
+                && entry.info_hash != "0000000000000000000000000000000000000000"
+        })
         .map(|entry| Torrent {
             name: entry.name.clone(),
             magnet_link: format!("magnet:?xt=urn:btih:{}", entry.info_hash),
@@ -84,6 +89,7 @@ fn parse_piratebay(content: &str) -> Result<Vec<Torrent>, Box<dyn Error + Send +
 #[cfg(test)]
 mod test {
     static TEST_DATA: &str = include_str!("test_data/piratebay.json");
+    static TEST_DATA_EMPTY: &str = include_str!("test_data/piratebay-empty.json");
 
     #[test]
     fn test_parse_piratebay() {
@@ -94,5 +100,11 @@ mod test {
             assert!(torrent.seeders.is_some());
             assert!(torrent.leechers.is_some());
         }
+    }
+
+    #[test]
+    fn test_parse_piratebay_empty() {
+        let torrents = super::parse_piratebay(TEST_DATA_EMPTY).unwrap();
+        assert_eq!(torrents.len(), 0);
     }
 }

--- a/src/search_providers/test_data/piratebay-empty.json
+++ b/src/search_providers/test_data/piratebay-empty.json
@@ -1,0 +1,1 @@
+[{"id":"0","name":"No results returned","info_hash":"0000000000000000000000000000000000000000","leechers":"0","seeders":"0","num_files":"0","size":"0","username":"","added":"0","status":"member","category":"0","imdb":"","total_found":"1"}]


### PR DESCRIPTION
When no results are found, piratebay will return a pseudo result with id
"0" and the name "No results returned". This should fix #56.